### PR TITLE
.indexOf() replaced with jQuery inArray to avoid issues with IE8 and older

### DIFF
--- a/jqueryTranslator.js
+++ b/jqueryTranslator.js
@@ -56,7 +56,7 @@
         },
         isTranslatable : function(language){
             if (this.options.defaultLang === language) { return false; }
-            else { return (this.options.skip.indexOf(language) === -1); }
+            else { return ($.inArray(language, this.options.skip) === -1); }
         },
         loadLanguages : function(){
             var loaded = 0, maxLoad = Translate.languages.length * Translate.packages.length;


### PR DESCRIPTION
JavaScript method .indexOf() was replaced with jQuery.inArray() because .indexOf() is not supported by old versions of Internet Explorer (IE8 and older). Please update the min version and the JS files at the demo if you accept the fix.
